### PR TITLE
http2 server perf for asp.net core 3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,8 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+#dotnet
+bin/
+obj/
+server.crt

--- a/netcore/Program.cs
+++ b/netcore/Program.cs
@@ -1,0 +1,53 @@
+using System.Net;
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace netcore_http2
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder
+                    .ConfigureKestrel(options =>
+                    {
+                        options.Listen(IPAddress.Any, 8080, listenOptions =>
+                        {
+                            listenOptions.Protocols = HttpProtocols.Http2;
+                            X509Certificate2 cert = new X509Certificate2(X509Certificate.CreateFromCertFile("server.crt"));
+                            listenOptions.UseHttps(cert);
+                        });
+                    })
+                    .Configure(app =>
+                    {
+
+                        app.UseHttpsRedirection();
+
+                        app.UseRouting();
+
+                        app.UseEndpoints(endpoints =>
+                        {
+                            endpoints.Map("/", httpContext =>
+                            {
+                                httpContext.Response.ContentType = "text/plain; charset=utf-8";
+                                httpContext.Response.StatusCode = (int)HttpStatusCode.OK;
+
+                                return httpContext.Response.WriteAsync("Hello world!");
+                            });
+                        });
+                    });
+                });
+    }
+}

--- a/netcore/README.md
+++ b/netcore/README.md
@@ -1,0 +1,5 @@
+1. install ASP.NET Core Runtime 3.1 as described [here](https://docs.microsoft.com/en-us/dotnet/core/install/linux-debian#install-the-runtime)
+1. clone repo
+1. navigate to /netcore
+1. make sure the **server.crt** is also present here
+1. execute **dotnet run** - the webservice answers on 8080

--- a/netcore/netcore-http2.csproj
+++ b/netcore/netcore-http2.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RootNamespace>netcore_http2</RootNamespace>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
http2 enabled asp.net core 3.1 webserver

as with the others:
- answers on 8080
- runs with minimal / default configurations
