### PR TITLE
changed to use a pfx file instead of crt/key combination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,10 @@ hs_err_pid*
 #dotnet
 bin/
 obj/
-server.crt
+
+#certificates
+*.crt
+*.csr
+*.key
+*.pem
+*.pfx

--- a/netcore/Program.cs
+++ b/netcore/Program.cs
@@ -26,7 +26,7 @@ namespace netcore_http2
                         options.Listen(IPAddress.Any, 8080, listenOptions =>
                         {
                             listenOptions.Protocols = HttpProtocols.Http2;
-                            X509Certificate2 cert = new X509Certificate2(X509Certificate.CreateFromCertFile("server.crt"));
+                            X509Certificate2 cert = new X509Certificate2("server.pfx", args[0]);
                             listenOptions.UseHttps(cert);
                         });
                     })
@@ -48,6 +48,6 @@ namespace netcore_http2
                             });
                         });
                     });
-                });
+                });               
     }
 }

--- a/netcore/README.md
+++ b/netcore/README.md
@@ -1,5 +1,5 @@
 1. install ASP.NET Core Runtime 3.1 as described [here](https://docs.microsoft.com/en-us/dotnet/core/install/linux-debian#install-the-runtime)
 1. clone repo
 1. navigate to /netcore
-1. make sure the **server.crt** is also present here
-1. execute **dotnet run** - the webservice answers on 8080
+1. make sure the **server.pfx** is also present here
+1. execute **dotnet run {{cert_pass}}** - the webservice answers on 8080

--- a/netcore/README.md
+++ b/netcore/README.md
@@ -1,6 +1,6 @@
 1. install ASP.NET Core SDK 3.1 as described [here](https://docs.microsoft.com/en-us/dotnet/core/install/linux-debian#install-the-sdk)
 1. clone repo
 1. navigate to /netcore
-1. use **generate-cert.sh** to generate a **server.pfx** certificate in the same folder - make sure to specify all passwords
+1. use **generate-cert.sh** to generate a **server.pfx** certificate in the same folder - make sure to specify all passwords [link](https://razvangoga.blob.core.windows.net/share/http2-certificate-generation.png)
 1. execute **dotnet run {{cert_pass}}** - the webservice answers on 8080
 

--- a/netcore/README.md
+++ b/netcore/README.md
@@ -1,5 +1,6 @@
-1. install ASP.NET Core Runtime 3.1 as described [here](https://docs.microsoft.com/en-us/dotnet/core/install/linux-debian#install-the-runtime)
+1. install ASP.NET Core SDK 3.1 as described [here](https://docs.microsoft.com/en-us/dotnet/core/install/linux-debian#install-the-sdk)
 1. clone repo
 1. navigate to /netcore
-1. make sure the **server.pfx** is also present here
+1. use **generate-cert.sh** to generate a **server.pfx** certificate in the same folder - make sure to specify all passwords
 1. execute **dotnet run {{cert_pass}}** - the webservice answers on 8080
+

--- a/netcore/generate-cert.ps1
+++ b/netcore/generate-cert.ps1
@@ -1,0 +1,6 @@
+openssl genrsa -des3 -out server.key 2048
+openssl rsa -in server.key -out server.key
+openssl req -new -key server.key -out server.csr
+openssl x509 -req -days 365 -in server.csr -signkey server.key -out server.crt
+
+openssl pkcs12 -export -out server.pfx -inkey server.key -in server.crt

--- a/netcore/generate-cert.sh
+++ b/netcore/generate-cert.sh
@@ -1,0 +1,6 @@
+openssl genrsa -des3 -out server.key 2048
+openssl rsa -in server.key -out server.key
+openssl req -new -key server.key -out server.csr
+openssl x509 -req -days 365 -in server.csr -signkey server.key -out server.crt
+
+openssl pkcs12 -export -out server.pfx -inkey server.key -in server.crt


### PR DESCRIPTION
changed to use a pfx file instead of crt/key combination

pfx is generated with openssl with **openssl pkcs12 -export -out server.pfx -inkey server.key -in server.crt**
there is a **generate-cert.sh** included with all openssl commands

you will need to pass the extract password as an argument like **dotnet run {{cert_pass}}**

tested and works on Windows / Ubuntu on Windows Subsystem for Linux / Ubuntu 18.04 VM
